### PR TITLE
fix: replace deprecated data.http.body and data.aws_region.name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
   enabled                 = module.this.enabled
   userpool_id             = var.userpool_id
-  userpool_discovery_data = local.enabled ? jsondecode(data.http.cognito_user_pool[0].body) : null
+  userpool_discovery_data = local.enabled ? jsondecode(data.http.cognito_user_pool[0].response_body) : null
 
   aws_kv_namespace = trim(coalesce(var.aws_kv_namespace, "cognito-userpool-clients/${local.userpool_id}"), "/")
-  aws_region_name  = local.enabled ? data.aws_region.current[0].name : ""
+  aws_region_name  = local.enabled ? data.aws_region.current[0].region : ""
 
   defaults = merge(var.client_defaults, { userpool_id = var.userpool_id })
 

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
 
     http = {


### PR DESCRIPTION
## Summary

Resolves deprecation warnings emitted by the `hashicorp/http` and `hashicorp/aws` providers:

- `data.http.body` -> `data.http.response_body` (deprecated in `hashicorp/http` 3.x)
- `data.aws_region.name` -> `data.aws_region.region` (deprecated in `hashicorp/aws` 6.0)

Also bumps the `aws` provider constraint from `>= 5.0.0` to `>= 6.0.0` since `data.aws_region.region` was introduced in v6.

## Related Issue

Closes #5

## Warnings before this change

```
Warning: Value derived from a deprecated source
  on .terraform/modules/.../main.tf line 4, in locals:
   4:   userpool_discovery_data = local.enabled ? jsondecode(data.http.cognito_user_pool[0].body) : null
This value is derived from data.http.cognito_user_pool.body, which is deprecated.

Warning: Value derived from a deprecated source
  on .terraform/modules/.../main.tf line 7, in locals:
   7:   aws_region_name  = local.enabled ? data.aws_region.current[0].name : ""
This value is derived from data.aws_region.current.name, which is deprecated with the following message:
name is deprecated. Use region instead.
```

## Validation

- `terraform fmt -recursive -check` passes
- `terraform init -backend=false` succeeds
- `terraform validate` reports `Success! The configuration is valid.`