### PR TITLE
ci: fix tflint config and pin/bump github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Bump Version
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: minor
           custom_release_rules: bug:patch:Fixes,chore:patch:Chores,docs:patch:Documentation,feat:minor:Features,refactor:minor:Refactors,test:patch:Tests,ci:patch:Development,dev:patch:Development
 
       - name: Create Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         name: Check PR for Semantic Commit Message
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Cache Terraform Plugins
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/.terraform.d/plugin-cache
           key: tf-plugins-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Suggest Terraform Format
         if: github.event_name == 'pull_request'
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
         with:
           tool_name: terraform-fmt
           level: warning
@@ -48,7 +48,7 @@ jobs:
         run: terraform fmt -recursive -check
 
       - name: Validate Terraform
-        uses: reviewdog/action-terraform-validate@v1
+        uses: reviewdog/action-terraform-validate@4aaf1db71358f4f35ff414d656334e0ce3c34ce5 # v1.17.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
@@ -56,16 +56,16 @@ jobs:
           fail_level: error
 
       - name: Lint Terraform
-        uses: reviewdog/action-tflint@v1
+        uses: reviewdog/action-tflint@54a5e5aed57dcfbb4662ec548de876df33d6288d # v1.25.0
         with:
           reporter: github-pr-review
           filter_mode: nofilter
           fail_level: error
+          tflint_init: true
 
       - name: Lint GitHub Actions
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           reporter: github-pr-check
           fail_level: error
           filter_mode: nofilter
-

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,44 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,11 @@
 output "userpool_id" {
-  value = local.userpool_id
+  description = "ID of the Cognito user pool the module is configured against."
+  value       = local.userpool_id
 }
 
 output "userpool_discovery_data" {
-  value = local.userpool_discovery_data
+  description = "Decoded OpenID Connect discovery document for the Cognito user pool."
+  value       = local.userpool_discovery_data
 }
 
 output "clients" {


### PR DESCRIPTION
## Summary

Fixes the `lint` job failures and warnings seen on recent CI runs (e.g. [run 26183952225](https://github.com/cruxstack/terraform-aws-cognito-userpool-clients/actions/runs/26183952225)).

### Failures resolved

1. **`Lint Terraform` step failing**
   ```
   Failed to load TFLint config; failed to load file: open .tflint.hcl: no such file or directory
   ```
   `reviewdog/action-tflint@v1` defaults `tflint_config` to `.tflint.hcl`, and TFLint 0.62+ now hard-errors when the explicit config target is missing. This PR adds a minimal `.tflint.hcl` (the bundled `terraform` ruleset with the recommended preset plus a handful of style rules) and sets `tflint_init: true` on the workflow step so the plugin is installed in CI.
2. **Node.js 20 deprecation annotation** on `actions/cache`, `actions/checkout`, `hashicorp/setup-terraform`. Resolved by bumping to the latest major release of each action (all are now on Node.js 24).

### Hygiene changes

- Every action in `test.yml`, `release.yml`, and `semantic-check.yml` is now pinned to a commit SHA with a `# vX.Y.Z` comment.
- Bumped versions:
  - `actions/checkout` v4 -> **v6.0.2**
  - `hashicorp/setup-terraform` v3 -> **v4.0.1**
  - `actions/cache` v4 -> **v5.0.5**
  - `reviewdog/action-suggester` v1 -> **v1.24.0**
  - `reviewdog/action-terraform-validate` v1 -> **v1.17.3**
  - `reviewdog/action-tflint` v1 -> **v1.25.0**
  - `reviewdog/action-actionlint` v1 -> **v1.72.0**
  - `mathieudutour/github-tag-action` v6.1 -> **v6.2**
  - `ncipollo/release-action` v1.12.0 -> **v1.21.0**
  - `amannn/action-semantic-pull-request` v5.2.0 -> **v6.1.1**
- Added missing `description` to `output "userpool_id"` and `output "userpool_discovery_data"` (surfaced by the newly enabled `terraform_documented_outputs` rule).

### Notes on the tflint config

The `tflint-ruleset-aws` plugin is intentionally **not** enabled. Its naming rules statically evaluate string templates such as `"cognito-userpool-clients/${local.userpool_id}"`, but `var.userpool_id` has no default (it's required), so the plugin hits `Cannot include a null value in a string template` and aborts. The bundled terraform ruleset still gives us the high-value lint checks (naming convention, documented vars/outputs, typed vars, unused declarations, deprecated index/interpolation, required version/providers).

## Validation

- `terraform fmt -recursive -check` -> clean
- `terraform validate` -> Success
- `tflint --init && tflint --call-module-type=all` -> exit 0, no findings
- `actionlint` -> no issues